### PR TITLE
[Taskset Generator] Change the time allocated for sporadic tasks

### DIFF
--- a/C/src/TaskSetGenerator/BasicTaskSetGeneratorTemplate.lf
+++ b/C/src/TaskSetGenerator/BasicTaskSetGeneratorTemplate.lf
@@ -86,7 +86,7 @@ reactor SimpleRunner(num_task:int(10), total_time:time(10 sec), utilization:floa
         if (self->periodic) {
             exe_time = (long long int) ((self->utilization * self->period) / self->num_task);
         } else {
-            exe_time = (long long int) ((self->total_time * self->utilization) / self->num_task);
+            exe_time = (long long int) ((self->utilization * self->total_time) / (2 * (self->num_task - self->utilization)));
         }
         for (int i = 0; i < self->num_task; i++) {
             task_config_t message;

--- a/C/src/TaskSetGenerator/gui.py
+++ b/C/src/TaskSetGenerator/gui.py
@@ -34,7 +34,7 @@ def step(num_workers, scheduler_type):
     for key, value in char_to_replace.items():
         contents = contents.replace(key, value)
 
-    filename = f'practice_{scheduler_type}_{num_workers}'
+    filename = f'{"sporadic" if periodicity.get() == 1 else "periodic"}_{scheduler_type}_{num_workers}'
     filepath = f'{WORKING_DIR}/.gui/src/{filename}.lf'
     with open(filepath, "w") as lf_file:
         lf_file.write(contents)


### PR DESCRIPTION
At the time when the taskset generator was first designed, it assumed that each task is **executed only once**, and that all of the tasks have the same execution time.
In this assumption, the time allocated to each task can be obtained by simply dividing the total time allocated to all tasks by the number of tasks. (It can be shown in the picture below.)

![image](https://user-images.githubusercontent.com/43602849/177400678-5880e851-c8ed-4203-a05a-20269a640475.png)

However, the generator later changed the sporadic task to the way it was assigned randomly. 
In this case, if any task with an execution time t is scheduled at t′, the same task is scheduled at t′+t+random(0,T).
Based on this assumption, each task may be executed only once or **several times** at random instants.
Therefore, the execution time allocated to the task must be adjusted, but the current code does not indicate this.

My suggestion is that if the random function is uniformly distributed and the number of tasks is large, the average value of random(0, T) is convergent to T/2. 
In this case, if the time allocated to one task is t, the sporadic task may be treated as a period function with a period t + T/2.
Using this, t can be obtained as shown in the following figure.

![image](https://user-images.githubusercontent.com/43602849/177412748-501d9edb-8301-4e48-afae-920aa7b41326.png)

This pull request allocates this newly obtained time to the sporadic task.

